### PR TITLE
Improve performance

### DIFF
--- a/cocoa/Barliman/mk-and-rel-interp/interp.scm
+++ b/cocoa/Barliman/mk-and-rel-interp/interp.scm
@@ -448,9 +448,9 @@
 
 (define (list-split-ground st xs)
   (let loop ((rprefix '()) (xs xs))
-    (let ((tm (walk xs st)))
+    (let ((tm (walk xs (state-S st))))
       (if (pair? tm)
-        (loop (cons (walk (car tm) st) rprefix) (cdr tm))
+        (loop (cons (walk (car tm) (state-S st)) rprefix) (cdr tm))
         (values rprefix xs)))))
 
 (define (eval-application rands aenv a* body-goal)

--- a/cocoa/Barliman/mk-and-rel-interp/test-old-interp.scm
+++ b/cocoa/Barliman/mk-and-rel-interp/test-old-interp.scm
@@ -131,9 +131,9 @@
 
 (define (list-split-ground st xs)
   (let loop ((rprefix '()) (xs xs))
-    (let ((tm (walk xs st)))
+    (let ((tm (walk xs (state-S st))))
       (if (pair? tm)
-        (loop (cons (walk (car tm) st) rprefix) (cdr tm))
+        (loop (cons (walk (car tm) (state-S st)) rprefix) (cdr tm))
         (values rprefix xs)))))
 
 (define (eval-application rands aenv a* body-goal)

--- a/cocoa/Barliman/mk-and-rel-interp/test-old-interp.scm
+++ b/cocoa/Barliman/mk-and-rel-interp/test-old-interp.scm
@@ -58,7 +58,7 @@
        (== `(define ,name (lambda ,args ,body)) defn)
        (eval-expo `(letrec ((,name (lambda ,args ,body))) ,e) env val)))
 
-    ;((handle-matcho expr env val))
+    ((handle-matcho expr env val))
 
     ((fresh (p-name x body letrec-body)
        ;; single-function variadic letrec version


### PR DESCRIPTION
Fix improper walks by list-split-ground

We were only getting the benefit of set-var-val! vars by not properly
passing the state's substitution to walk.  This fix reduces latency by
between 1/3 and 2/3 on the harder benchmarks (the harder, the more
savings, as usual).