### PR TITLE
Additional big tests for mk-and-rel-interp

### DIFF
--- a/cocoa/Barliman/mk-and-rel-interp/test-fib-aps-synth.scm
+++ b/cocoa/Barliman/mk-and-rel-interp/test-fib-aps-synth.scm
@@ -97,3 +97,98 @@
          (s . z)))))
   
  )
+
+;; Like the peano-synth-fib-aps 3 above, but we also synthesize one of the values for one of the base cases
+(time
+  (test "peano-synth-fib-aps 4"
+     (let ()
+       (define (ans-allTests)
+         (define (results)
+           (run 1 (defns ACC1 ACC2)
+             (let ()
+               (fresh (BASE A B begin-body)
+
+                 ;; skeleton
+                 (== `((define zero?
+                         (lambda (n)
+                           (equal? 'z n)))
+                       (define add1
+                         (lambda (n)
+                           (cons 's n)))
+                       (define sub1
+                         (lambda (n)
+                           (and (equal? (car n) 's)
+                                (cdr n))))
+                       (define +
+                         (lambda (n m)
+                           (if (zero? n)
+                               m
+                               (add1 (+ (sub1 n) m)))))
+                       (define -
+                         (lambda (n m)
+                           (if (zero? m)
+                               n
+                               (sub1 (- n (sub1 m))))))
+                       (define fib-aps
+                         (lambda (n a1 a2)
+                           (if (zero? n)
+                               ,BASE
+                               (if (zero? (sub1 n))
+                                   a2
+                                   (fib-aps (- n '(s . z)) ,A ,B))))))
+                     defns)
+
+                 (appendo defns
+                          `(((lambda x x)
+                             (fib-aps 'z ',ACC1 ',ACC2)
+                             (fib-aps '(s . z) ',ACC1 ',ACC2)
+                             (fib-aps '(s s . z) ',ACC1 ',ACC2)
+                             (fib-aps '(s s s . z) ',ACC1 ',ACC2)
+                             (fib-aps '(s s s s . z) ',ACC1 ',ACC2)
+                             (fib-aps '(s s s s s . z) ',ACC1 ',ACC2)))
+                          begin-body)
+                 (evalo `(begin . ,begin-body)
+                        '(z
+                          (s . z)
+                          (s . z)
+                          (s s . z)
+                          (s s s . z)
+                          (s s s s s . z)))))))
+         (let ((results-fast (begin (set! allow-incomplete-search? #t) (results))))
+           (if (null? results-fast)
+               (begin (set! allow-incomplete-search? #f) (results))
+               results-fast)))
+       (ans-allTests))
+
+     ;; result!
+     '(((((define zero?
+            (lambda (n)
+              (equal? 'z n)))
+          (define add1
+            (lambda (n)
+              (cons 's n)))
+          (define sub1
+            (lambda (n)
+              (and (equal? (car n) 's)
+                   (cdr n))))
+          (define +
+            (lambda (n m)
+              (if (zero? n)
+                  m
+                  (add1 (+ (sub1 n) m)))))
+          (define -
+            (lambda (n m)
+              (if (zero? m)
+                  n
+                  (sub1 (- n (sub1 m))))))
+          (define fib-aps
+            (lambda (n a1 a2)
+              (if (zero? n)
+                  a1
+                  (if (zero? (sub1 n))
+                      a2
+                      (fib-aps (- n '(s . z)) a2 (+ a1 a2)))))))
+         z
+         (s . z)))))
+
+ )

--- a/cocoa/Barliman/mk-and-rel-interp/test-old-interp.scm
+++ b/cocoa/Barliman/mk-and-rel-interp/test-old-interp.scm
@@ -186,6 +186,7 @@
 
 (set! allow-incomplete-search? #t)
 
+;; Check that a proof of C given (A (A => B) (B => C)) is valid
 (time
   (test 'prover-1
     (run 1 (q)
@@ -219,6 +220,8 @@
         q))
     '((#t))))
 
+;; Check that a proof of C given (A (A => B) (B => C)) is valid
+;; Doing the entire thing in a letrec
 (time
   (test 'prover-2
     (run 1 (q)
@@ -251,6 +254,8 @@
         q))
     '((#t))))
 
+;; *Synthesize* a valid proof of C given (A (A => B) (B => C))
+;; Doing the entire thing in a letrec
 (time
   (test 'prover-3
     (run 1 (prf)
@@ -285,6 +290,8 @@
               (((A => B) (A (A => B) (B => C)) assumption ())
                (A (A (A => B) (B => C)) assumption ())))))))))
 
+;; *Synthesize* a proof of the hypothetical syllogism
+;; Doing the entire thing in a letrec
 (time
   (test 'prover-4
     (run 1 (prf)

--- a/cocoa/Barliman/mk-and-rel-interp/test-proofo.scm
+++ b/cocoa/Barliman/mk-and-rel-interp/test-proofo.scm
@@ -51,3 +51,61 @@
                   (A (A (A => B) (B => C)) assumption ()))))))))
  
  )
+
+
+(time
+  (test "proofo 2"
+     (let ()
+       (define (ans-allTests)
+         (define (results)
+           (run 1 (prf)
+             (let ()
+               (fresh
+                (body)
+                (== prf `(((A => B) => ((B => C) => (A => C))) () . ,body))
+                (evalo
+                 `(letrec ([member?
+                            (lambda (x ls)
+                              (if (null? ls) #f
+                                  (if (equal? (car ls) x) #t
+                                      (member? x (cdr ls)))))])
+                    (letrec ([proof?
+                              (lambda (proof)
+                                (match proof
+                                  [`(,A ,assms assumption ()) (member? A assms)]
+                                  [`(,B ,assms modus-ponens
+                                        (((,A => ,B) ,assms ,r1 ,ants1)
+                                         (,A ,assms ,r2 ,ants2)))
+                                   (and (proof? (list (list A '=> B) assms r1 ants1))
+                                        (proof? (list A assms r2 ants2)))]
+                                  [`((,A => ,B) ,assms conditional
+                                     ((,B (,A . ,assms) ,rule ,ants)))
+                                   (proof? (list B (cons A assms) rule ants))]
+                                  ))])
+                      (proof? ',prf)))
+                 #t)))))
+         (let ((results-fast (begin (set! allow-incomplete-search? #t) (results))))
+           (if (null? results-fast)
+               (begin (set! allow-incomplete-search? #f) (results))
+               results-fast)))
+       (ans-allTests))
+
+     ;; result!
+'(((((A => B) => ((B => C) => (A => C)))
+       ()
+       conditional
+       ((((B => C) => (A => C))
+         ((A => B))
+         conditional
+         (((A => C)
+           ((B => C) (A => B))
+           conditional
+           ((C (A (B => C) (A => B))
+               modus-ponens
+               (((B => C) (A (B => C) (A => B)) assumption ())
+                (B (A (B => C) (A => B))
+                   modus-ponens
+                   (((A => B) (A (B => C) (A => B)) assumption ())
+                    (A (A (B => C) (A => B)) assumption ()))))))))))))))
+
+ )


### PR DESCRIPTION
We used these two big tests in the staged-miniKanren Barliman comparison. 

Added some comments to the `test-old-interp.scm` file, not essential but helpful to me.